### PR TITLE
fix: correct url for retrieving card and bank reactions by id

### DIFF
--- a/library/src/atomic/banks/BasisTheoryAtomicBanks.ts
+++ b/library/src/atomic/banks/BasisTheoryAtomicBanks.ts
@@ -73,7 +73,7 @@ export const BasisTheoryAtomicBanks = new CrudBuilder(
     ): Promise<Token> {
       return this.client
         .get(
-          `/${atomicBankId}/reaction/${reactionTokenId}`,
+          `/${atomicBankId}/reactions/${reactionTokenId}`,
           createRequestConfig(options, {
             transformResponse: transformTokenResponseCamelCase,
           })

--- a/library/src/atomic/cards/BasisTheoryAtomicCards.ts
+++ b/library/src/atomic/cards/BasisTheoryAtomicCards.ts
@@ -75,7 +75,7 @@ export const BasisTheoryAtomicCards = new CrudBuilder(
     ): Promise<Token> {
       return this.client
         .get(
-          `/${atomicCardId}/reaction/${reactionTokenId}`,
+          `/${atomicCardId}/reactions/${reactionTokenId}`,
           createRequestConfig(options, {
             transformResponse: transformTokenResponseCamelCase,
           })

--- a/library/test/atomic-banks.test.ts
+++ b/library/test/atomic-banks.test.ts
@@ -394,7 +394,7 @@ describe('Atomic Banks', () => {
       const createdBy = chance.string();
       const createdAt = chance.string();
 
-      client.onGet(`/${atomicBankId}/reaction/${reactionTokenId}`).reply(
+      client.onGet(`/${atomicBankId}/reactions/${reactionTokenId}`).reply(
         200,
         /* eslint-disable camelcase */
         JSON.stringify({
@@ -422,7 +422,7 @@ describe('Atomic Banks', () => {
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(
-        `/${atomicBankId}/reaction/${reactionTokenId}`
+        `/${atomicBankId}/reactions/${reactionTokenId}`
       );
       expect(client.history.get[0].headers).toMatchObject({
         [API_KEY_HEADER]: expect.any(String),
@@ -451,7 +451,7 @@ describe('Atomic Banks', () => {
       const _apiKey = chance.string();
       const correlationId = chance.string();
 
-      client.onGet(`/${atomicBankId}/reaction/${reactionTokenId}`).reply(
+      client.onGet(`/${atomicBankId}/reactions/${reactionTokenId}`).reply(
         200,
         /* eslint-disable camelcase */
         JSON.stringify({
@@ -482,7 +482,7 @@ describe('Atomic Banks', () => {
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(
-        `/${atomicBankId}/reaction/${reactionTokenId}`
+        `/${atomicBankId}/reactions/${reactionTokenId}`
       );
       expect(client.history.get[0].headers).toMatchObject({
         [API_KEY_HEADER]: _apiKey,
@@ -496,7 +496,7 @@ describe('Atomic Banks', () => {
       const status = errorStatus();
 
       client
-        .onGet(`/${atomicBankId}/reaction/${reactionTokenId}`)
+        .onGet(`/${atomicBankId}/reactions/${reactionTokenId}`)
         .reply(status);
 
       const promise = bt.atomicBanks.retrieveReaction(

--- a/library/test/atomic-cards.test.ts
+++ b/library/test/atomic-cards.test.ts
@@ -456,7 +456,7 @@ describe('Atomic Cards', () => {
       const createdBy = chance.string();
       const createdAt = chance.string();
 
-      client.onGet(`/${atomicCardId}/reaction/${reactionTokenId}`).reply(
+      client.onGet(`/${atomicCardId}/reactions/${reactionTokenId}`).reply(
         200,
         /* eslint-disable camelcase */
         JSON.stringify({
@@ -484,7 +484,7 @@ describe('Atomic Cards', () => {
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(
-        `/${atomicCardId}/reaction/${reactionTokenId}`
+        `/${atomicCardId}/reactions/${reactionTokenId}`
       );
       expect(client.history.get[0].headers).toMatchObject({
         [API_KEY_HEADER]: expect.any(String),
@@ -513,7 +513,7 @@ describe('Atomic Cards', () => {
       const _apiKey = chance.string();
       const correlationId = chance.string();
 
-      client.onGet(`/${atomicCardId}/reaction/${reactionTokenId}`).reply(
+      client.onGet(`/${atomicCardId}/reactions/${reactionTokenId}`).reply(
         200,
         /* eslint-disable camelcase */
         JSON.stringify({
@@ -544,7 +544,7 @@ describe('Atomic Cards', () => {
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(
-        `/${atomicCardId}/reaction/${reactionTokenId}`
+        `/${atomicCardId}/reactions/${reactionTokenId}`
       );
       expect(client.history.get[0].headers).toMatchObject({
         [API_KEY_HEADER]: _apiKey,
@@ -558,7 +558,7 @@ describe('Atomic Cards', () => {
       const status = errorStatus();
 
       client
-        .onGet(`/${atomicCardId}/reaction/${reactionTokenId}`)
+        .onGet(`/${atomicCardId}/reactions/${reactionTokenId}`)
         .reply(status);
 
       const promise = bt.atomicCards.retrieveReaction(


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Corrects the URL format for retrieving Atomic Card and Atomic Bank reactions by id. `reaction` -> `reactions`

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [X] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [X] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [X] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [x] Description of Change
- [x] Description of outside testing if applicable.
- [x] Description of Roll Forward / Backward Procedure
- [x] Documentation updated for Change
