### PR TITLE
feat: Standardizing audit fields across entities

### DIFF
--- a/library/src/applications/types.ts
+++ b/library/src/applications/types.ts
@@ -1,4 +1,5 @@
 import type { PaginatedQuery } from '../service';
+import type { Auditable } from '../types';
 
 const APPLICATION_TYPES = [
   'server_to_server',
@@ -9,15 +10,13 @@ const APPLICATION_TYPES = [
 
 type ApplicationType = typeof APPLICATION_TYPES[number];
 
-interface Application {
+interface Application extends Auditable {
   id: string;
   tenantId: string;
   name: string;
   key?: string;
   type: ApplicationType;
   permissions: string[];
-  createdAt: string;
-  modifiedAt: string;
 }
 
 type CreateApplicationModel = Pick<Application, 'name' | 'type'> &

--- a/library/src/atomic/types.ts
+++ b/library/src/atomic/types.ts
@@ -1,13 +1,12 @@
 import type { TokenType } from '../tokens';
+import type { Auditable } from '../types';
 
-interface Atomic {
+interface Atomic extends Auditable {
   id: string;
   tenantId: string;
   type: TokenType;
   fingerprint: string;
   metadata?: Record<string, string>;
-  createdBy: string;
-  createdAt: string;
 }
 
 interface ReactRequest {

--- a/library/src/reactor-formulas/types.ts
+++ b/library/src/reactor-formulas/types.ts
@@ -1,10 +1,11 @@
 import type { PaginatedQuery } from '../service';
 import type { TokenType } from '../tokens';
+import type { Auditable } from '../types';
 
 type FormulaType = 'official' | 'private';
 type DataType = 'string' | 'boolean' | 'number';
 
-interface ReactorFormula {
+interface ReactorFormula extends Auditable {
   id: string;
   name: string;
   description?: string;
@@ -14,8 +15,6 @@ interface ReactorFormula {
   code: string;
   configuration: ReactorFormulaConfig[];
   requestParameters: ReactorFormulaRequestParam[];
-  createdAt: string;
-  modifiedAt?: string;
 }
 
 interface ReactorFormulaConfig {
@@ -33,7 +32,7 @@ interface ReactorFormulaRequestParam {
 
 type CreateReactorFormulaModel = Omit<
   ReactorFormula,
-  'id' | 'createdAt' | 'modifiedAt'
+  'id' | 'createdAt' | 'createdBy' | 'modifiedAt' | 'modifiedBy'
 >;
 
 interface ReactorFormulaQuery extends PaginatedQuery {

--- a/library/src/reactors/types.ts
+++ b/library/src/reactors/types.ts
@@ -1,15 +1,14 @@
 import type { ReactorFormula } from '../reactor-formulas/types';
 import type { PaginatedQuery } from '../service';
 import type { TokenType } from '../tokens/types';
+import type { Auditable } from '../types';
 
-interface Reactor {
+interface Reactor extends Auditable {
   id: string;
   tenantId: string;
   name: string;
   formula: ReactorFormula;
   configuration: Record<string, string>;
-  createdAt: string;
-  modifiedAt: string;
 }
 
 type CreateReactorModel = Pick<Reactor, 'name' | 'configuration'> & {

--- a/library/src/tenants/types.ts
+++ b/library/src/tenants/types.ts
@@ -1,9 +1,9 @@
-interface Tenant {
+import type { Auditable } from '../types';
+
+interface Tenant extends Auditable {
   id: string;
   ownerId: string;
   name: string;
-  createdAt: string;
-  modifiedAt: string;
 }
 
 type UpdateTenantModel = Pick<Tenant, 'name'>;

--- a/library/src/tokens/types.ts
+++ b/library/src/tokens/types.ts
@@ -1,4 +1,5 @@
 import type { PaginatedQuery } from '../service';
+import type { Auditable } from '../types';
 
 type Primitive = string | number | boolean | null;
 type DataObject = {
@@ -19,7 +20,7 @@ interface TokenEncryption {
   kek: TokenEncryptionKey;
 }
 
-interface Token {
+interface Token extends Auditable {
   id: string;
   tenantId: string;
   type: TokenType;
@@ -28,8 +29,6 @@ interface Token {
   metadata?: Record<string, string>;
   encryption?: TokenEncryption;
   children?: Token[];
-  createdBy: string;
-  createdAt: string;
 }
 
 type CreateTokenModel = Pick<

--- a/library/src/types.ts
+++ b/library/src/types.ts
@@ -40,6 +40,13 @@ interface BasisTheoryInitOptions {
   elementsBaseUrl?: string;
 }
 
+interface Auditable {
+  createdBy?: string;
+  createdAt?: string;
+  modifiedBy?: string;
+  modifiedAt?: string;
+}
+
 declare global {
   interface Window {
     BasisTheoryElements?: BasisTheoryElements;
@@ -57,4 +64,5 @@ export type {
   EncryptionProviderOptions,
   EncryptionOptions,
   BasisTheoryInitOptions,
+  Auditable,
 };

--- a/library/test/applications.test.ts
+++ b/library/test/applications.test.ts
@@ -47,15 +47,22 @@ describe('Applications', () => {
   describe('get by key', () => {
     it('should get by key', async () => {
       const id = chance.string();
-      const createdDate = chance.string();
+      const createdBy = chance.string();
+      const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       client.onGet('/key').reply(
         200,
+        /* eslint-disable camelcase */
         JSON.stringify({
           id,
-          // eslint-disable-next-line camelcase
-          created_date: createdDate,
+          created_at: createdAt,
+          created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
+        /* eslint-enable camelcase */
       );
 
       const retrieveByKey = jest.spyOn(bt.applications, 'retrieveByKey');
@@ -63,11 +70,17 @@ describe('Applications', () => {
       // should call retrieveByKey, and not have own implementation
       expect(await bt.applications.getApplicationByKey()).toEqual({
         id,
-        createdDate,
+        createdAt,
+        createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(await bt.applications.retrieveByKey()).toEqual({
         id,
-        createdDate,
+        createdAt,
+        createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(retrieveByKey).toHaveBeenCalledTimes(2);
       expect(client.history.get.length).toBe(2);
@@ -81,17 +94,24 @@ describe('Applications', () => {
 
     it('should get by key with options', async () => {
       const id = chance.string();
-      const createdDate = chance.string();
+      const createdBy = chance.string();
+      const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
       const _apiKey = chance.string();
       const correlationId = chance.string();
 
       client.onGet('/key').reply(
         200,
+        /* eslint-disable camelcase */
         JSON.stringify({
           id,
-          // eslint-disable-next-line camelcase
-          created_date: createdDate,
+          created_at: createdAt,
+          created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
+        /* eslint-enable camelcase */
       );
 
       expect(
@@ -101,7 +121,10 @@ describe('Applications', () => {
         })
       ).toEqual({
         id,
-        createdDate,
+        createdAt,
+        createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].headers).toMatchObject({
@@ -125,22 +148,32 @@ describe('Applications', () => {
     it('should regenerate key', async () => {
       const id = chance.string();
       const key = chance.string();
-      const modifiedDate = chance.string();
+      const createdBy = chance.string();
+      const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       client.onPost(`${id}/regenerate`).reply(
         200,
+        /* eslint-disable camelcase */
         JSON.stringify({
           id,
           key,
-          // eslint-disable-next-line camelcase
-          modified_date: modifiedDate,
+          created_at: createdAt,
+          created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
+        /* eslint-enable camelcase */
       );
 
       expect(await bt.applications.regenerateKey(id)).toEqual({
         id,
         key,
-        modifiedDate,
+        createdAt,
+        createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.post.length).toBe(1);
       expect(client.history.post[0].headers).toMatchObject({
@@ -151,18 +184,25 @@ describe('Applications', () => {
     it('should regenerate key with options', async () => {
       const id = chance.string();
       const key = chance.string();
-      const modifiedDate = chance.string();
+      const createdBy = chance.string();
+      const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
       const _apiKey = chance.string();
       const correlationId = chance.string();
 
       client.onPost(`${id}/regenerate`).reply(
         200,
+        /* eslint-disable camelcase */
         JSON.stringify({
           id,
           key,
-          // eslint-disable-next-line camelcase
-          modified_date: modifiedDate,
+          created_at: createdAt,
+          created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
+        /* eslint-enable camelcase */
       );
 
       expect(
@@ -173,7 +213,10 @@ describe('Applications', () => {
       ).toEqual({
         id,
         key,
-        modifiedDate,
+        createdAt,
+        createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.post.length).toBe(1);
       expect(client.history.post[0].headers).toMatchObject({

--- a/library/test/atomic-banks.test.ts
+++ b/library/test/atomic-banks.test.ts
@@ -98,6 +98,8 @@ describe('Atomic Banks', () => {
         },
         createdBy: chance.string(),
         createdAt: chance.string(),
+        modifiedBy: chance.string(),
+        modifiedAt: chance.string(),
         id: atomicBankId,
         type: 'bank',
         tenantId: chance.string(),
@@ -185,6 +187,8 @@ describe('Atomic Banks', () => {
       };
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       client.onGet(`/${id}/decrypt`).reply(
         200,
@@ -201,6 +205,8 @@ describe('Atomic Banks', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -217,6 +223,8 @@ describe('Atomic Banks', () => {
         metadata,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(`/${id}/decrypt`);
@@ -238,6 +246,8 @@ describe('Atomic Banks', () => {
       };
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
       const _apiKey = chance.string();
       const correlationId = chance.string();
 
@@ -256,6 +266,8 @@ describe('Atomic Banks', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -277,6 +289,8 @@ describe('Atomic Banks', () => {
         metadata,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(`/${id}/decrypt`);
@@ -326,6 +340,8 @@ describe('Atomic Banks', () => {
 
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       client.onPost(`/${id}/react`).reply(
         201,
@@ -338,6 +354,8 @@ describe('Atomic Banks', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -356,6 +374,8 @@ describe('Atomic Banks', () => {
         metadata,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.post.length).toBe(1);
       expect(client.history.post[0].url).toStrictEqual(`/${id}/react`);
@@ -400,6 +420,8 @@ describe('Atomic Banks', () => {
 
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
       const _apiKey = chance.string();
       const correlationId = chance.string();
 
@@ -414,6 +436,8 @@ describe('Atomic Banks', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -439,6 +463,8 @@ describe('Atomic Banks', () => {
         metadata,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.post.length).toBe(1);
       expect(client.history.post[0].url).toStrictEqual(`/${id}/react`);
@@ -487,6 +513,8 @@ describe('Atomic Banks', () => {
       /* eslint-enable camelcase */
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       client.onGet(`/${atomicBankId}/reactions/${reactionTokenId}`).reply(
         200,
@@ -499,6 +527,8 @@ describe('Atomic Banks', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -513,6 +543,8 @@ describe('Atomic Banks', () => {
         metadata,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(
@@ -542,6 +574,8 @@ describe('Atomic Banks', () => {
 
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
       const _apiKey = chance.string();
       const correlationId = chance.string();
 
@@ -556,6 +590,8 @@ describe('Atomic Banks', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -573,6 +609,8 @@ describe('Atomic Banks', () => {
         metadata,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(

--- a/library/test/atomic-cards.test.ts
+++ b/library/test/atomic-cards.test.ts
@@ -121,6 +121,8 @@ describe('Atomic Cards', () => {
         },
         createdBy: chance.string(),
         createdAt: chance.string(),
+        modifiedBy: chance.string(),
+        modifiedAt: chance.string(),
         id: atomicCardId,
         type: 'card',
         tenantId: chance.string(),
@@ -209,6 +211,8 @@ describe('Atomic Cards', () => {
       const fingerprint = chance.string();
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       /* eslint-disable camelcase */
       const metadata = {
@@ -249,6 +253,8 @@ describe('Atomic Cards', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -265,6 +271,8 @@ describe('Atomic Cards', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -281,6 +289,8 @@ describe('Atomic Cards', () => {
       const fingerprint = chance.string();
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       /* eslint-disable camelcase */
       const metadata = {
@@ -324,6 +334,8 @@ describe('Atomic Cards', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -345,6 +357,8 @@ describe('Atomic Cards', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -397,6 +411,8 @@ describe('Atomic Cards', () => {
 
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       client.onPost(`/${id}/react`).reply(
         201,
@@ -410,6 +426,8 @@ describe('Atomic Cards', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -429,6 +447,8 @@ describe('Atomic Cards', () => {
         metadata,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.post.length).toBe(1);
       expect(client.history.post[0].url).toStrictEqual(`/${id}/react`);
@@ -474,6 +494,8 @@ describe('Atomic Cards', () => {
 
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
       const _apiKey = chance.string();
       const correlationId = chance.string();
 
@@ -489,6 +511,8 @@ describe('Atomic Cards', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -515,6 +539,8 @@ describe('Atomic Cards', () => {
         metadata,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.post.length).toBe(1);
       expect(client.history.post[0].url).toStrictEqual(`/${id}/react`);
@@ -565,6 +591,8 @@ describe('Atomic Cards', () => {
 
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       client.onGet(`/${atomicCardId}/reactions/${reactionTokenId}`).reply(
         200,
@@ -577,6 +605,8 @@ describe('Atomic Cards', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -591,6 +621,8 @@ describe('Atomic Cards', () => {
         metadata,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(
@@ -620,6 +652,8 @@ describe('Atomic Cards', () => {
 
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
       const _apiKey = chance.string();
       const correlationId = chance.string();
 
@@ -634,6 +668,8 @@ describe('Atomic Cards', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -651,6 +687,8 @@ describe('Atomic Cards', () => {
         metadata,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(

--- a/library/test/tenants.test.ts
+++ b/library/test/tenants.test.ts
@@ -31,7 +31,9 @@ describe('Tenants', () => {
       const id = chance.string();
       const ownerId = chance.string();
       const name = chance.string();
+      const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
       const modifiedAt = chance.string();
 
       client.onGet().reply(
@@ -42,7 +44,9 @@ describe('Tenants', () => {
           owner_id: ownerId,
           name,
           created_at: createdAt,
+          created_by: createdBy,
           modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -52,7 +56,9 @@ describe('Tenants', () => {
         ownerId,
         name,
         createdAt,
+        createdBy,
         modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].headers).toMatchObject({
@@ -64,7 +70,9 @@ describe('Tenants', () => {
       const id = chance.string();
       const ownerId = chance.string();
       const name = chance.string();
+      const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
       const modifiedAt = chance.string();
       const _apiKey = chance.string();
       const correlationId = chance.string();
@@ -77,7 +85,9 @@ describe('Tenants', () => {
           owner_id: ownerId,
           name,
           created_at: createdAt,
+          created_by: createdBy,
           modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -92,7 +102,9 @@ describe('Tenants', () => {
         ownerId,
         name,
         createdAt,
+        createdBy,
         modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].headers).toMatchObject({

--- a/library/test/tokens.test.ts
+++ b/library/test/tokens.test.ts
@@ -63,6 +63,8 @@ describe('Tokens', () => {
 
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       client.onGet(id).reply(
         200,
@@ -76,6 +78,8 @@ describe('Tokens', () => {
           metadata,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -89,6 +93,8 @@ describe('Tokens', () => {
         metadata,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].headers).toMatchObject({
@@ -104,6 +110,8 @@ describe('Tokens', () => {
       const data = chance.string();
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
       const query = {
         children: chance.bool(),
         childrenType: chance.string({
@@ -123,6 +131,8 @@ describe('Tokens', () => {
           data,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -137,6 +147,8 @@ describe('Tokens', () => {
         data,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(
@@ -157,6 +169,8 @@ describe('Tokens', () => {
       const data = chance.string();
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
       const query = {
         children: chance.bool(),
         childrenType: chance.string({
@@ -176,6 +190,8 @@ describe('Tokens', () => {
           data,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -193,6 +209,8 @@ describe('Tokens', () => {
         data,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(
@@ -225,6 +243,8 @@ describe('Tokens', () => {
       const data = chance.string();
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       client.onGet(`/${id}/decrypt`).reply(
         200,
@@ -237,6 +257,8 @@ describe('Tokens', () => {
           data,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -249,6 +271,8 @@ describe('Tokens', () => {
         data,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(`/${id}/decrypt`);
@@ -265,6 +289,8 @@ describe('Tokens', () => {
       const data = chance.string();
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
       const query = {
         children: chance.bool(),
         childrenType: chance.string({
@@ -285,6 +311,8 @@ describe('Tokens', () => {
           data,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -299,6 +327,8 @@ describe('Tokens', () => {
         data,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(url);
@@ -317,6 +347,8 @@ describe('Tokens', () => {
       const data = chance.string();
       const createdBy = chance.string();
       const createdAt = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
       const query = {
         children: chance.bool(),
         childrenType: chance.string({
@@ -337,6 +369,8 @@ describe('Tokens', () => {
           data,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -354,6 +388,8 @@ describe('Tokens', () => {
         data,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
       expect(client.history.get.length).toBe(1);
       expect(client.history.get[0].url).toStrictEqual(url);
@@ -688,6 +724,8 @@ describe('Tokens', () => {
 
       const createdAt = chance.string();
       const createdBy = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       client.onPost(`/${parentId}/children`).reply(
         201,
@@ -696,6 +734,8 @@ describe('Tokens', () => {
           ...tokenPayload,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -705,6 +745,8 @@ describe('Tokens', () => {
           ...tokenPayload,
           createdAt,
           createdBy,
+          modifiedAt,
+          modifiedBy,
         }
       );
 
@@ -728,6 +770,8 @@ describe('Tokens', () => {
 
       const createdAt = chance.string();
       const createdBy = chance.string();
+      const modifiedBy = chance.string();
+      const modifiedAt = chance.string();
 
       client.onPost(`/${parentId}/children`).reply(
         201,
@@ -736,6 +780,8 @@ describe('Tokens', () => {
           ...tokenPayload,
           created_at: createdAt,
           created_by: createdBy,
+          modified_at: modifiedAt,
+          modified_by: modifiedBy,
         })
         /* eslint-enable camelcase */
       );
@@ -749,6 +795,8 @@ describe('Tokens', () => {
         ...tokenPayload,
         createdAt,
         createdBy,
+        modifiedAt,
+        modifiedBy,
       });
 
       expect(client.history.post.length).toBe(1);


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds standard audit fields on all auditable entities
- _Note: We will treat this as a feature, but this may be a breaking change for consumers that expected audit fields to be non-null. We will make a pass through the UI's to ensure nulls are handled appropriately._

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
