### PR TITLE
feat(POC): add example logic for setting query params with nested objects

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   root: true,
   extends: '@basis-theory/eslint-config/typescript',
+  rules: {
+    'import/no-unresolved': 'off',
+  },
 };

--- a/library/src/common/utils.ts
+++ b/library/src/common/utils.ts
@@ -251,12 +251,20 @@ const getQueryParams = <Q>(query: Q): string => {
   if (keys.length) {
     const params = new URLSearchParams();
 
-    const appendSafe = (key: string, value: unknown): void => {
+    const appendSafe = (
+      key: string,
+      value: unknown,
+      toSnakeCaseOrNotToSnakeCaseThatIsTheQuestion = true
+    ): void => {
       const type = typeof value;
+
+      const parsedKey = toSnakeCaseOrNotToSnakeCaseThatIsTheQuestion
+        ? snakeCase(key)
+        : key;
 
       // eslint-disable-next-line unicorn/no-null
       if (value === null || ['boolean', 'number', 'string'].includes(type)) {
-        params.append(snakeCase(key), value as string);
+        params.append(parsedKey, value as string);
       }
     };
 
@@ -266,6 +274,16 @@ const getQueryParams = <Q>(query: Q): string => {
       if (Array.isArray(value)) {
         value.forEach((aValue) => {
           appendSafe(String(key), aValue);
+        });
+      } else if (value && typeof value === 'object') {
+        const objectKeys = Object.keys(value);
+
+        objectKeys.forEach((objectKey) => {
+          appendSafe(
+            `${key}.${objectKey}`,
+            ((value as unknown) as Record<string, string>)[objectKey],
+            false
+          );
         });
       } else {
         appendSafe(String(key), value);

--- a/library/test/setup/utils.ts
+++ b/library/test/setup/utils.ts
@@ -411,8 +411,8 @@ const testList = <T>(param: () => TestListParam<T>): void => {
       [chance.string()],
       {},
     ],
-    obj: {
-      [chance.string()]: chance.string(),
+    metadata: {
+      fooBar: chance.string({ alpha: true }),
     },
     fn: (): undefined => undefined,
     [Symbol(chance.string())]: Symbol(chance.string()),
@@ -483,7 +483,7 @@ const testList = <T>(param: () => TestListParam<T>): void => {
     } as PaginatedList<T>);
     expect(client.history.get.length).toBe(1);
     expect(client.history.get[0].url).toStrictEqual(
-      `/?page=${page}&size=${size}&nul=null&camel_case=${query.camelCase}&bool=${query.bool}&int=${query.int}&float=${query.float}&str=${query.str}&arr=${query.arr[0]}&arr=${query.arr[1]}&arr=${query.arr[2]}&arr=${query.arr[3]}`
+      `/?page=${page}&size=${size}&nul=null&camel_case=${query.camelCase}&bool=${query.bool}&int=${query.int}&float=${query.float}&str=${query.str}&arr=${query.arr[0]}&arr=${query.arr[1]}&arr=${query.arr[2]}&arr=${query.arr[3]}&metadata.fooBar=${query.metadata.fooBar}`
     );
     expect(client.history.get[0].headers).toMatchObject({
       [API_KEY_HEADER]: expect.any(String),
@@ -524,7 +524,7 @@ const testList = <T>(param: () => TestListParam<T>): void => {
     } as PaginatedList<T>);
     expect(client.history.get.length).toBe(1);
     expect(client.history.get[0].url).toStrictEqual(
-      `/?page=${page}&size=${size}&nul=null&camel_case=${query.camelCase}&bool=${query.bool}&int=${query.int}&float=${query.float}&str=${query.str}&arr=${query.arr[0]}&arr=${query.arr[1]}&arr=${query.arr[2]}&arr=${query.arr[3]}`
+      `/?page=${page}&size=${size}&nul=null&camel_case=${query.camelCase}&bool=${query.bool}&int=${query.int}&float=${query.float}&str=${query.str}&arr=${query.arr[0]}&arr=${query.arr[1]}&arr=${query.arr[2]}&arr=${query.arr[3]}&metadata.fooBar=${query.metadata.fooBar}`
     );
     expect(client.history.get[0].headers).toMatchObject({
       [API_KEY_HEADER]: apiKey,


### PR DESCRIPTION
🚧 🚧 🚧 

## DO NOT MERGE