### PR TITLE
feat: add value prop to elements create and update objects

### DIFF
--- a/src/types/elements/options.ts
+++ b/src/types/elements/options.ts
@@ -133,6 +133,7 @@ export type {
   CreateCardVerificationCodeElementOptions,
   UpdateCardVerificationCodeElementOptions,
   CardElementValue,
+  CardExpirationDateValue,
 };
 
 export { ELEMENTS_TYPES };

--- a/src/types/elements/options.ts
+++ b/src/types/elements/options.ts
@@ -59,11 +59,8 @@ interface CardElementValue {
 }
 
 interface CardExpirationDateValue {
-  // disabling camecalse so that the element value matches the API data
-  /* eslint-disable camelcase */
-  expiration_month?: number;
-  expiration_year?: number;
-  /* eslint-enable camelcase */
+  month?: number;
+  year?: number;
 }
 
 type CreateCardElementOptions = CustomizableElementOptions & {

--- a/src/types/elements/options.ts
+++ b/src/types/elements/options.ts
@@ -59,8 +59,8 @@ interface CardElementValue {
 }
 
 interface CardExpirationDateValue {
-  month?: number;
-  year?: number;
+  month: number;
+  year: number;
 }
 
 type CreateCardElementOptions = CustomizableElementOptions & {

--- a/src/types/elements/options.ts
+++ b/src/types/elements/options.ts
@@ -30,6 +30,7 @@ interface SanitizedElementOptions {
   iconPosition?: string;
   cardBrand?: string;
   autoComplete?: string;
+  value?: string;
 }
 
 type ElementOptions = ElementInternalOptions & SanitizedElementOptions;
@@ -47,12 +48,32 @@ interface AutoCompleteOption {
 type CustomizableElementOptions = Pick<ElementOptions, 'style' | 'disabled'> &
   AutoCompleteOption;
 
-type CreateCardElementOptions = CustomizableElementOptions;
+interface CardElementValue {
+  number: string;
+  // disabling camecalse so that the element value matches the API data
+  /* eslint-disable camelcase */
+  expiration_month?: number;
+  expiration_year?: number;
+  /* eslint-enable camelcase */
+  cvc?: string;
+}
+
+interface CardExpirationDateValue {
+  // disabling camecalse so that the element value matches the API data
+  /* eslint-disable camelcase */
+  expiration_month?: number;
+  expiration_year?: number;
+  /* eslint-enable camelcase */
+}
+
+type CreateCardElementOptions = CustomizableElementOptions & {
+  value?: CardElementValue;
+};
 
 type UpdateCardElementOptions = CreateCardElementOptions;
 
 type CreateTextElementOptions = CustomizableElementOptions &
-  Pick<ElementOptions, 'placeholder' | 'mask' | 'password'> &
+  Pick<ElementOptions, 'placeholder' | 'mask' | 'password' | 'value'> &
   TransformOption &
   Required<Pick<ElementOptions, 'targetId'>> & {
     'aria-label'?: string;
@@ -64,7 +85,7 @@ type UpdateTextElementOptions = Omit<
 >;
 
 type CreateCardNumberElementOptions = CustomizableElementOptions &
-  Pick<ElementOptions, 'placeholder' | 'iconPosition'> &
+  Pick<ElementOptions, 'placeholder' | 'iconPosition' | 'value'> &
   Required<Pick<ElementOptions, 'targetId'>> & {
     'aria-label'?: string;
   };
@@ -78,6 +99,7 @@ type CreateCardExpirationDateElementOptions = CustomizableElementOptions &
   Pick<ElementOptions, 'placeholder'> &
   Required<Pick<ElementOptions, 'targetId'>> & {
     'aria-label'?: string;
+    value?: CardExpirationDateValue;
   };
 
 type UpdateCardExpirationDateElementOptions = Omit<
@@ -86,7 +108,7 @@ type UpdateCardExpirationDateElementOptions = Omit<
 >;
 
 type CreateCardVerificationCodeElementOptions = CustomizableElementOptions &
-  Pick<ElementOptions, 'placeholder' | 'cardBrand'> &
+  Pick<ElementOptions, 'placeholder' | 'cardBrand' | 'value'> &
   Required<Pick<ElementOptions, 'targetId'>> & {
     'aria-label'?: string;
   };
@@ -113,6 +135,7 @@ export type {
   UpdateCardExpirationDateElementOptions,
   CreateCardVerificationCodeElementOptions,
   UpdateCardVerificationCodeElementOptions,
+  CardElementValue,
 };
 
 export { ELEMENTS_TYPES };

--- a/src/types/elements/options.ts
+++ b/src/types/elements/options.ts
@@ -49,7 +49,7 @@ type CustomizableElementOptions = Pick<ElementOptions, 'style' | 'disabled'> &
   AutoCompleteOption;
 
 interface CardElementValue {
-  number: string;
+  number?: string;
   // disabling camecalse so that the element value matches the API data
   /* eslint-disable camelcase */
   expiration_month?: number;


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds `value` prop to creation object for all Elements.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
