### PR TITLE
feat: add setValue method to elements, other qol improvements

### DIFF
--- a/src/BasisTheory.ts
+++ b/src/BasisTheory.ts
@@ -85,12 +85,12 @@ export class BasisTheory
   private _proxies?: Proxies;
 
   public init(
-    apiKey: string,
+    apiKey: string | undefined,
     options?: BasisTheoryInitOptionsWithoutElements
   ): Promise<IBasisTheory>;
 
   public init(
-    apiKey: string,
+    apiKey: string | undefined,
     options: BasisTheoryInitOptionsWithElements
   ): Promise<IBasisTheory & BasisTheoryElements>;
 

--- a/src/elements/services/tokens.ts
+++ b/src/elements/services/tokens.ts
@@ -49,7 +49,9 @@ const delegateTokens = (
     public retrieve(
       id: string,
       requestOptions?: RequestOptions
-    ): Promise<Token> {
+      //  returned data type as any to avoid casting when trying to retrieve token.data.<prop>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): Promise<Token<any>> {
       if (elements !== undefined) {
         return elements.tokens.retrieve(id, requestOptions);
       }

--- a/src/elements/services/tokens.ts
+++ b/src/elements/services/tokens.ts
@@ -49,7 +49,7 @@ const delegateTokens = (
     public retrieve(
       id: string,
       requestOptions?: RequestOptions
-      //  returned data type as any to avoid casting when trying to retrieve token.data.<prop>
+      // avoid casting when accessing token data props
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): Promise<Token<any>> {
       if (elements !== undefined) {

--- a/src/tokens/BasisTheoryTokens.ts
+++ b/src/tokens/BasisTheoryTokens.ts
@@ -42,7 +42,7 @@ export const BasisTheoryTokens = new CrudBuilder(
     public retrieve(
       id: string,
       options: RequestOptions = {}
-      // returned data type as any to avoid casting when trying to retrieve token.data.<prop>
+      // avoid casting when accessing token data props
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): Promise<Token<any>> {
       const url = `/${id}`;

--- a/src/tokens/BasisTheoryTokens.ts
+++ b/src/tokens/BasisTheoryTokens.ts
@@ -39,7 +39,12 @@ export const BasisTheoryTokens = new CrudBuilder(
       super(_options);
     }
 
-    public retrieve(id: string, options: RequestOptions = {}): Promise<Token> {
+    public retrieve(
+      id: string,
+      options: RequestOptions = {}
+      // returned data type as any to avoid casting when trying to retrieve token.data.<prop>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): Promise<Token<any>> {
       const url = `/${id}`;
 
       return this.client

--- a/src/types/elements/elements.ts
+++ b/src/types/elements/elements.ts
@@ -19,8 +19,11 @@ import type {
   UpdateCardExpirationDateElementOptions,
   UpdateCardVerificationCodeElementOptions,
   UpdateTextElementOptions,
+  CardElementValue,
+  CardExpirationDateValue,
 } from './options';
 import type { Tokenize, Tokens } from './services';
+import { DataElementReference } from './shared';
 
 interface BaseElement<UpdateOptions, ElementEvents> {
   readonly mounted: boolean;
@@ -36,14 +39,20 @@ interface BaseElement<UpdateOptions, ElementEvents> {
   ): Subscription;
 }
 
-type CardElement = BaseElement<UpdateCardElementOptions, CardElementEvents>;
+type CardElement = BaseElement<UpdateCardElementOptions, CardElementEvents> & {
+  setValue(value: CardElementValue<'reference'>): void;
+};
 
-type TextElement = BaseElement<UpdateTextElementOptions, TextElementEvents>;
+type TextElement = BaseElement<UpdateTextElementOptions, TextElementEvents> & {
+  setValue(value: DataElementReference): void;
+};
 
 type CardNumberElement = BaseElement<
   UpdateCardNumberElementOptions,
   CardNumberElementEvents
->;
+> & {
+  setValue(value: DataElementReference): void;
+};
 
 type CardExpirationDateElement = BaseElement<
   UpdateCardExpirationDateElementOptions,
@@ -51,12 +60,15 @@ type CardExpirationDateElement = BaseElement<
 > & {
   month(): ElementWrapper<CardExpirationDateElement>;
   year(): ElementWrapper<CardExpirationDateElement>;
+  setValue(value: CardExpirationDateValue<'reference'>): void;
 };
 
 type CardVerificationCodeElement = BaseElement<
   UpdateCardVerificationCodeElementOptions,
   CardVerificationCodeElementEvents
->;
+> & {
+  setValue(value: DataElementReference): void;
+};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ElementWrapper<T extends BaseElement<any, any> = BaseElement<any, any>> = {

--- a/src/types/elements/options.ts
+++ b/src/types/elements/options.ts
@@ -58,15 +58,15 @@ interface CardElementValue<T extends ElementValueType> {
   number?: T extends 'reference' ? DataElementReference : string;
   // disabling camecalse so that the element value matches the API data
   /* eslint-disable camelcase */
-  expiration_month?: T extends 'reference' ? DataElementReference : string;
-  expiration_year?: T extends 'reference' ? DataElementReference : string;
+  expiration_month?: T extends 'reference' ? DataElementReference : number;
+  expiration_year?: T extends 'reference' ? DataElementReference : number;
   /* eslint-enable camelcase */
   cvc?: T extends 'reference' ? DataElementReference : string;
 }
 
 interface CardExpirationDateValue<T extends ElementValueType> {
-  month: T extends 'reference' ? DataElementReference : string;
-  year: T extends 'reference' ? DataElementReference : string;
+  month: T extends 'reference' ? DataElementReference : number;
+  year: T extends 'reference' ? DataElementReference : number;
 }
 
 type CreateCardElementOptions = CustomizableElementOptions & {
@@ -104,7 +104,7 @@ type CreateCardExpirationDateElementOptions = CustomizableElementOptions &
   Pick<ElementOptions, 'placeholder'> &
   Required<Pick<ElementOptions, 'targetId'>> & {
     'aria-label'?: string;
-    value?: CardExpirationDateValue<'static'>;
+    value?: CardExpirationDateValue<'static'> | string;
   };
 
 type UpdateCardExpirationDateElementOptions = Omit<

--- a/src/types/elements/services/tokens.ts
+++ b/src/types/elements/services/tokens.ts
@@ -10,7 +10,9 @@ type CreateToken = CreateTokenModel<ElementValue>;
 type UpdateToken = UpdateTokenModel<ElementValue>;
 
 type Tokens = Create<Token, CreateToken> &
-  Retrieve<Token> &
+  //  returned data type as any to avoid casting when trying to retrieve token.data.<prop>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Retrieve<Token<any>> &
   Update<Token, UpdateToken>;
 
 export type { Tokens, CreateToken, UpdateToken };

--- a/src/types/elements/services/tokens.ts
+++ b/src/types/elements/services/tokens.ts
@@ -10,7 +10,7 @@ type CreateToken = CreateTokenModel<ElementValue>;
 type UpdateToken = UpdateTokenModel<ElementValue>;
 
 type Tokens = Create<Token, CreateToken> &
-  //  returned data type as any to avoid casting when trying to retrieve token.data.<prop>
+  // avoid casting when accessing token data props
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Retrieve<Token<any>> &
   Update<Token, UpdateToken>;

--- a/src/types/sdk/services/tokens.ts
+++ b/src/types/sdk/services/tokens.ts
@@ -30,7 +30,9 @@ interface SearchTokensRequest {
 interface Tokens
   extends Create<Token, CreateToken>,
     Update<Token, UpdateToken>,
-    Retrieve<Token>,
+    //  returned data type as any to avoid casting when trying to retrieve token.data.<prop>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Retrieve<Token<any>>,
     Delete,
     List<Token, ListTokensQuery> {
   createAssociation(

--- a/src/types/sdk/services/tokens.ts
+++ b/src/types/sdk/services/tokens.ts
@@ -30,7 +30,7 @@ interface SearchTokensRequest {
 interface Tokens
   extends Create<Token, CreateToken>,
     Update<Token, UpdateToken>,
-    //  returned data type as any to avoid casting when trying to retrieve token.data.<prop>
+    // avoid casting when accessing token data props
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Retrieve<Token<any>>,
     Delete,


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds `setValue`methods to all elements
- Set type for token `data` as `any` on retrieve
  - without this you couldn't do `token.data.<someprop>` w/o casting to `any`
- Set `apiKey` type as `string | undefined` to avoid having to cast environment variables
- Change value of expiration/month year to `number` where applicable to match API
- Allow `string` to be passed as a `static` value to `CardExpirationDateElement` 

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
