### PR TITLE
fix: add expiring application props to create and update models

### DIFF
--- a/src/types/models/applications.ts
+++ b/src/types/models/applications.ts
@@ -40,15 +40,17 @@ type Condition = {
 
 type CreateApplication = Pick<
   Application,
-  'name' | 'type' | 'expiresAt' | 'canCreateExpiringApplications'
-> &
-  Partial<Pick<Application, 'permissions' | 'rules'>>;
+  | 'name'
+  | 'type'
+  | 'permissions'
+  | 'rules'
+  | 'canCreateExpiringApplications'
+  | 'expiresAt'
+>;
 
-type UpdateApplication = Partial<
-  Pick<
-    Application,
-    'name' | 'permissions' | 'rules' | 'canCreateExpiringApplications'
-  >
+type UpdateApplication = Pick<
+  Application,
+  'name' | 'permissions' | 'rules' | 'canCreateExpiringApplications'
 >;
 
 export type {

--- a/src/types/models/applications.ts
+++ b/src/types/models/applications.ts
@@ -38,11 +38,17 @@ type Condition = {
   value: string;
 };
 
-type CreateApplication = Pick<Application, 'name' | 'type'> &
+type CreateApplication = Pick<
+  Application,
+  'name' | 'type' | 'expiresAt' | 'canCreateExpiringApplications'
+> &
   Partial<Pick<Application, 'permissions' | 'rules'>>;
 
 type UpdateApplication = Partial<
-  Pick<Application, 'name' | 'permissions' | 'rules'>
+  Pick<
+    Application,
+    'name' | 'permissions' | 'rules' | 'canCreateExpiringApplications'
+  >
 >;
 
 export type {


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds `expiresAt` and `canCreateExpiringApplications` to `CreateApplication` model
- Adds `canCreateExpiringApplications` to `UpdateApplication` model

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
