### PR TITLE
feat: allow changing the elements client url

### DIFF
--- a/src/BasisTheory.ts
+++ b/src/BasisTheory.ts
@@ -272,7 +272,9 @@ export class BasisTheory
       throw new Error('Invalid format for the given Elements base url.');
     }
 
-    const elements = await loadElements();
+    const elements = await loadElements(
+      (this.initOptions as BasisTheoryInitOptionsWithElements).elementsClientUrl
+    );
 
     await (elements as BasisTheoryElementsInternal).init(
       apiKey,

--- a/src/elements/load.ts
+++ b/src/elements/load.ts
@@ -8,7 +8,9 @@ import { findScript, injectScript } from './script';
 
 let elementsPromise: Promise<BasisTheoryElements>;
 
-const loadElements = (): Promise<BasisTheoryElements> => {
+const loadElements = (
+  elementsClientUrl?: string
+): Promise<BasisTheoryElements> => {
   if (!elementsPromise) {
     elementsPromise = new Promise((resolve, reject) => {
       if (typeof window !== 'object') {
@@ -24,7 +26,20 @@ const loadElements = (): Promise<BasisTheoryElements> => {
       }
 
       try {
-        const url = `https://${process.env.JS_HOST}/elements`;
+        let url = `https://${process.env.JS_HOST}/elements`;
+
+        if (typeof elementsClientUrl !== 'undefined') {
+          try {
+            const urlObject = new URL(elementsClientUrl);
+
+            url = urlObject.toString().replace(/\/$/u, '');
+          } catch {
+            throw new Error(
+              'Invalid format for the given Elements client url.'
+            );
+          }
+        }
+
         let script = findScript(url);
 
         if (!script) {

--- a/src/types/sdk/sdk.ts
+++ b/src/types/sdk/sdk.ts
@@ -31,6 +31,7 @@ interface BasisTheoryInitOptionsWithoutElements extends BasisTheoryInitOptions {
 interface BasisTheoryInitOptionsWithElements extends BasisTheoryInitOptions {
   elements: true;
   elementsBaseUrl?: string;
+  elementsClientUrl?: string;
 }
 
 interface BasisTheoryInit {

--- a/test/elements.test.ts
+++ b/test/elements.test.ts
@@ -62,6 +62,17 @@ describe('Elements', () => {
       ).rejects.toThrow('Invalid format for the given Elements base url.');
     });
 
+    test('should throw error for invalid client elements url', async () => {
+      const bt = new BasisTheory();
+
+      await expect(() =>
+        bt.init(chance.string(), {
+          elements: true,
+          elementsClientUrl: chance.string(),
+        })
+      ).rejects.toThrow('Invalid format for the given Elements client url.');
+    });
+
     test('should resolve with a valid base elements url', () => {
       const bt = new BasisTheory();
       const validUrl = chance.url({ protocol: 'https' });
@@ -70,6 +81,19 @@ describe('Elements', () => {
         bt.init(chance.string(), {
           elements: true,
           elementsBaseUrl: validUrl,
+        })
+        // eslint-disable-next-line jest/no-restricted-matchers
+      ).resolves.toBe(bt);
+    });
+
+    test('should resolve with a valid client elements url', () => {
+      const bt = new BasisTheory();
+      const validUrl = chance.url({ protocol: 'https' });
+
+      expect(
+        bt.init(chance.string(), {
+          elements: true,
+          elementsClientUrl: validUrl,
         })
         // eslint-disable-next-line jest/no-restricted-matchers
       ).resolves.toBe(bt);


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Allows setting an `elementsClientUrl` to specify where from to load the client (for debugging purposes).

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
