### PR TITLE
feat: add 5s connection keep-alive to node requests

### DIFF
--- a/src/BasisTheory.ts
+++ b/src/BasisTheory.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import https from 'https';
 import type {
   BasisTheoryElements,
   BasisTheoryElementsInternal,
@@ -46,6 +47,7 @@ import {
   CLIENT_BASE_PATHS,
   DEFAULT_BASE_URL,
   DEFAULT_ELEMENTS_BASE_URL,
+  DEFAULT_KEEPALIVE_TIMEOUT_MS,
 } from './common';
 import {
   delegateTokenize,
@@ -62,11 +64,22 @@ import { BasisTheoryReactors } from './reactors';
 import { BasisTheorySessions } from './sessions';
 import { BasisTheoryTenants } from './tenants';
 
+const defaultAgent = (): https.Agent => {
+  try {
+    return new https.Agent({
+      keepAlive: true,
+      keepAliveMsecs: DEFAULT_KEEPALIVE_TIMEOUT_MS,
+    });
+  } catch {
+    return axios.defaults.httpsAgent;
+  }
+};
+
 const defaultInitOptions: Required<BasisTheoryInitOptionsWithoutElements> = {
   apiBaseUrl: DEFAULT_BASE_URL,
   elements: false,
   appInfo: {},
-  httpsAgent: axios.defaults.httpsAgent,
+  httpsAgent: defaultAgent(),
 };
 
 export class BasisTheory

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -10,6 +10,7 @@ const USER_AGENT_CLIENT = 'BasisTheoryJS';
 
 const DEFAULT_BASE_URL = `https://${process.env.API_HOST}`;
 const DEFAULT_ELEMENTS_BASE_URL = `https://${process.env.ELEMENTS_HOST}`;
+const DEFAULT_KEEPALIVE_TIMEOUT_MS = 5000;
 
 const CLIENT_BASE_PATHS: BasisTheoryServicesBasePathMap = {
   tokens: 'tokens',
@@ -76,4 +77,5 @@ export {
   DEFAULT_ELEMENTS_BASE_URL,
   CLIENT_BASE_PATHS,
   BROWSER_LIST,
+  DEFAULT_KEEPALIVE_TIMEOUT_MS,
 };

--- a/test/clients.test.ts
+++ b/test/clients.test.ts
@@ -7,6 +7,7 @@ import {
   CLIENT_BASE_PATHS,
   buildClientUserAgentString,
   buildUserAgentString,
+  DEFAULT_KEEPALIVE_TIMEOUT_MS,
 } from '@/common';
 import { BasisTheoryService } from '@/service';
 import { getTestAppInfo } from './setup/utils';
@@ -30,6 +31,10 @@ describe('clients', () => {
       },
       transformRequest: expect.any(Array),
       transformResponse: expect.any(Array),
+      httpsAgent: expect.objectContaining({
+        keepAlive: true,
+        keepAliveMsecs: DEFAULT_KEEPALIVE_TIMEOUT_MS,
+      }),
     };
 
     expect(create).toHaveBeenCalledWith({

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -21,6 +21,7 @@ const base = {
       stream: false,
       os: require.resolve('os-browserify/browser'),
       process: false,
+      https: false,
     },
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6942,6 +6942,11 @@ http-signature@~1.3.6:
     jsprim "^2.0.2"
     sshpk "^1.14.1"
 
+https-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+  integrity sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==
+
 https-proxy-agent@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds an agent w/ a 5s connection `Keep-Alive` for all axios requests to improve performance/reliability. 

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
