### PR TITLE
feat: adds interface for client for dual writing

### DIFF
--- a/src/BasisTheory.ts
+++ b/src/BasisTheory.ts
@@ -1,7 +1,7 @@
 import {
   Config,
-  makeRequestWithElementsCheck,
-  makeRequestWithoutElementsCheck,
+  makeRequestWithElementsPayloadCheck,
+  makeRequestWithoutElementsPayloadCheck,
 } from '@/common/BasisTheoryClient';
 import { BasisTheoryTransactions } from '@/transactions';
 import type {
@@ -279,7 +279,7 @@ export class BasisTheory
     payload: unknown,
     config?: Config
   ): Promise<unknown> {
-    return makeRequestWithElementsCheck(
+    return makeRequestWithElementsPayloadCheck(
       this._elements,
       'post',
       url,
@@ -289,7 +289,7 @@ export class BasisTheory
   }
 
   public put(url: string, payload: unknown, config?: Config): Promise<unknown> {
-    return makeRequestWithElementsCheck(
+    return makeRequestWithElementsPayloadCheck(
       this._elements,
       'put',
       url,
@@ -303,7 +303,7 @@ export class BasisTheory
     payload: unknown,
     config?: Config
   ): Promise<unknown> {
-    return makeRequestWithElementsCheck(
+    return makeRequestWithElementsPayloadCheck(
       this._elements,
       'patch',
       url,
@@ -313,11 +313,16 @@ export class BasisTheory
   }
 
   public get(url: string, config?: Config): Promise<unknown> {
-    return makeRequestWithoutElementsCheck(this._elements, 'get', url, config);
+    return makeRequestWithoutElementsPayloadCheck(
+      this._elements,
+      'get',
+      url,
+      config
+    );
   }
 
   public delete(url: string, config?: Config): Promise<unknown> {
-    return makeRequestWithoutElementsCheck(
+    return makeRequestWithoutElementsPayloadCheck(
       this._elements,
       'delete',
       url,

--- a/src/BasisTheory.ts
+++ b/src/BasisTheory.ts
@@ -1,3 +1,8 @@
+import {
+  Config,
+  makeRequestWithElementsCheck,
+  makeRequestWithoutElementsCheck,
+} from '@/common/BasisTheoryClient';
 import type {
   BasisTheoryElements,
   BasisTheoryElementsInternal,
@@ -258,6 +263,57 @@ export class BasisTheory
     options?: RequestOptions
   ): Promise<TokenizeData> {
     return assertInit(this._tokenize).tokenize(tokens, options);
+  }
+
+  public post(
+    url: string,
+    payload: unknown,
+    config?: Config
+  ): Promise<unknown> {
+    return makeRequestWithElementsCheck(
+      this._elements,
+      'post',
+      url,
+      payload,
+      config
+    );
+  }
+
+  public put(url: string, payload: unknown, config?: Config): Promise<unknown> {
+    return makeRequestWithElementsCheck(
+      this._elements,
+      'put',
+      url,
+      payload,
+      config
+    );
+  }
+
+  public patch(
+    url: string,
+    payload: unknown,
+    config?: Config
+  ): Promise<unknown> {
+    return makeRequestWithElementsCheck(
+      this._elements,
+      'patch',
+      url,
+      payload,
+      config
+    );
+  }
+
+  public get(url: string, config?: Config): Promise<unknown> {
+    return makeRequestWithoutElementsCheck(this._elements, 'get', url, config);
+  }
+
+  public delete(url: string, config?: Config): Promise<unknown> {
+    return makeRequestWithoutElementsCheck(
+      this._elements,
+      'delete',
+      url,
+      config
+    );
   }
 
   private async loadElements(apiKey: string): Promise<void> {

--- a/src/common/BasisTheoryClient.ts
+++ b/src/common/BasisTheoryClient.ts
@@ -25,10 +25,10 @@ const makeRequestWithElementsPayloadCheck = (
     return elements.client[method](url, payload, config);
   }
 
-  let errorMessageStart = 'Element not found in payload.';
+  let errorMessageStart = 'Elements not initialized.';
 
   if (elements) {
-    errorMessageStart = 'Elements not initialized.';
+    errorMessageStart = 'Element not found in payload.';
   }
 
   throw new NoElementsError(

--- a/src/common/BasisTheoryClient.ts
+++ b/src/common/BasisTheoryClient.ts
@@ -14,7 +14,7 @@ class NoElementsError extends Error {
   }
 }
 
-const makeRequestWithElementsCheck = (
+const makeRequestWithElementsPayloadCheck = (
   elements: BasisTheoryElementsInternal | undefined,
   method: MethodWithPayloads,
   url: string,
@@ -25,18 +25,18 @@ const makeRequestWithElementsCheck = (
     return elements.client[method](url, payload, config);
   }
 
-  let errorMessageStart = 'Element not found in payload';
+  let errorMessageStart = 'Element not found in payload.';
 
   if (elements) {
-    errorMessageStart = 'Element not initialized';
+    errorMessageStart = 'Elements not initialized.';
   }
 
   throw new NoElementsError(
-    `${errorMessageStart}. Use a regular HTTP client if no elements are needed.`
+    `${errorMessageStart} Use a regular HTTP client if no elements are needed.`
   );
 };
 
-const makeRequestWithoutElementsCheck = (
+const makeRequestWithoutElementsPayloadCheck = (
   elements: BasisTheoryElementsInternal | undefined,
   method: MethodWithoutPayloads,
   url: string,
@@ -53,6 +53,6 @@ const makeRequestWithoutElementsCheck = (
 
 export {
   Config,
-  makeRequestWithElementsCheck,
-  makeRequestWithoutElementsCheck,
+  makeRequestWithElementsPayloadCheck,
+  makeRequestWithoutElementsPayloadCheck,
 };

--- a/src/common/BasisTheoryClient.ts
+++ b/src/common/BasisTheoryClient.ts
@@ -20,7 +20,7 @@ const makeRequestWithElementsCheck = (
   url: string,
   payload: unknown,
   config: Config = {}
-) => {
+): Promise<unknown> => {
   if (elements?.hasElement(payload)) {
     return elements.client[method](url, payload, config);
   }
@@ -41,7 +41,7 @@ const makeRequestWithoutElementsCheck = (
   method: MethodWithoutPayloads,
   url: string,
   config: Config = {}
-) => {
+): Promise<unknown> => {
   if (elements) {
     return elements.client[method](url, config);
   }

--- a/src/common/BasisTheoryClient.ts
+++ b/src/common/BasisTheoryClient.ts
@@ -1,0 +1,58 @@
+import type { BasisTheoryElementsInternal } from '@/types/elements';
+
+type Config = {
+  headers?: Record<string, string>;
+};
+
+type MethodWithPayloads = 'post' | 'put' | 'patch';
+type MethodWithoutPayloads = 'get' | 'delete';
+
+class NoElementsError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'NoElementsError';
+  }
+}
+
+const makeRequestWithElementsCheck = (
+  elements: BasisTheoryElementsInternal | undefined,
+  method: MethodWithPayloads,
+  url: string,
+  payload: unknown,
+  config: Config = {}
+) => {
+  if (elements?.hasElement(payload)) {
+    return elements.client[method](url, payload, config);
+  }
+
+  let errorMessageStart = 'Element not found in payload';
+
+  if (elements) {
+    errorMessageStart = 'Element not initialized';
+  }
+
+  throw new NoElementsError(
+    `${errorMessageStart}. Use a regular HTTP client if no elements are needed.`
+  );
+};
+
+const makeRequestWithoutElementsCheck = (
+  elements: BasisTheoryElementsInternal | undefined,
+  method: MethodWithoutPayloads,
+  url: string,
+  config: Config = {}
+) => {
+  if (elements) {
+    return elements.client[method](url, config);
+  }
+
+  throw new NoElementsError(
+    'Elements not initialized. Use a regular HTTP client if no elements are needed.'
+  );
+};
+
+export {
+  Config,
+  makeRequestWithElementsCheck,
+  makeRequestWithoutElementsCheck,
+};

--- a/src/common/HttpClientError.ts
+++ b/src/common/HttpClientError.ts
@@ -1,0 +1,22 @@
+export class HttpClientError extends Error {
+  public readonly status: number;
+
+  public readonly data?: unknown;
+
+  public readonly headers?: unknown;
+
+  public constructor(
+    message: string,
+    status: number,
+    data?: unknown,
+    headers?: unknown
+  ) {
+    super(message);
+    this.name = 'HttpClientError';
+    this.status = status;
+    this.data = data;
+    this.headers = headers;
+
+    Object.setPrototypeOf(this, HttpClientError.prototype);
+  }
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -2,3 +2,4 @@ export * from './constants';
 export * from './utils';
 export { BasisTheoryApiError } from './BasisTheoryApiError';
 export { BasisTheoryValidationError } from './BasisTheoryValidationError';
+export { HttpClientError } from './HttpClientError';

--- a/src/types/elements/elements.ts
+++ b/src/types/elements/elements.ts
@@ -1,3 +1,4 @@
+import type { Config } from '@/common/BasisTheoryClient';
 import type {
   ElementEventListener,
   EventType,
@@ -112,12 +113,21 @@ interface BasisTheoryElements extends Tokenize {
   ): CardVerificationCodeElement;
 }
 
+interface ElementClient {
+  post(url: string, payload: unknown, config?: Config): Promise<unknown>;
+  put(url: string, payload: unknown, config?: Config): Promise<unknown>;
+  patch(url: string, payload: unknown, config?: Config): Promise<unknown>;
+  get(url: string, config?: Config): Promise<unknown>;
+  delete(url: string, config?: Config): Promise<unknown>;
+}
+
 interface BasisTheoryElementsInternal extends BasisTheoryElements {
   init: (
     apiKey: string | undefined,
     elementsBaseUrl: string
   ) => Promise<BasisTheoryElements>;
   hasElement: (payload: unknown) => boolean;
+  client: ElementClient;
 }
 
 declare global {

--- a/test/elements/httpClient.test.ts
+++ b/test/elements/httpClient.test.ts
@@ -1,0 +1,277 @@
+import { Chance } from 'chance';
+
+describe('elements http client', () => {
+  const chance = new Chance();
+  let BtElementImport: any;
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  describe('elements http client requests without element payloads (get, delete)', () => {
+    let mockGet: jest.Mock,
+      mockDelete: jest.Mock,
+      mockGetResponse: string,
+      mockDeleteResponse: string;
+
+    describe('elements has not been initialized', () => {
+      beforeEach(async () => {
+        jest.mock('@/elements', () => ({
+          ...jest.requireActual('@/elements'),
+          loadElements: jest.fn().mockReturnValue({
+            init: jest.fn().mockResolvedValue({}),
+          }),
+        }));
+        const { BasisTheory } = await import('@/BasisTheory');
+
+        BtElementImport = BasisTheory;
+      });
+
+      test('should throw NoElementsError', async () => {
+        const btElements = await new BtElementImport().init(chance.string());
+        const expectedUrl = chance.url();
+        const expectedConfig = {
+          [chance.string()]: chance.string(),
+        };
+
+        expect(() => btElements.get(expectedUrl, expectedConfig)).toThrow(
+          'Elements not initialized. Use a regular HTTP client if no elements are needed.'
+        );
+
+        expect(() => btElements.delete(expectedUrl, expectedConfig)).toThrow(
+          'Elements not initialized. Use a regular HTTP client if no elements are needed.'
+        );
+      });
+    });
+
+    describe('elements has been initialized', () => {
+      beforeEach(async () => {
+        mockGetResponse = chance.string();
+        mockDeleteResponse = chance.string();
+        mockGet = jest.fn().mockResolvedValue(mockGetResponse);
+        mockDelete = jest.fn().mockResolvedValue(mockDeleteResponse);
+
+        jest.mock('@/elements', () => ({
+          ...jest.requireActual('@/elements'),
+          loadElements: jest.fn().mockReturnValue({
+            client: {
+              get: mockGet,
+              delete: mockDelete,
+            },
+            init: jest.fn().mockResolvedValue({}),
+            hasElement: jest.fn().mockReturnValue(true),
+          }),
+        }));
+        const { BasisTheory } = await import('@/BasisTheory');
+
+        BtElementImport = BasisTheory;
+      });
+
+      test('should delegate http client request method to elements', async () => {
+        const btElements = await new BtElementImport().init(chance.string(), {
+          elements: true,
+        });
+        const expectedUrl = chance.url();
+        const expectedConfig = {
+          [chance.string()]: chance.string(),
+        };
+
+        const getResponse = await btElements.get(expectedUrl, expectedConfig);
+
+        expect(mockGet).toHaveBeenCalledTimes(1);
+        expect(mockGet).toHaveBeenCalledWith(expectedUrl, expectedConfig);
+        expect(getResponse).toStrictEqual(mockGetResponse);
+
+        const deleteResponse = await btElements.delete(
+          expectedUrl,
+          expectedConfig
+        );
+
+        expect(mockDelete).toHaveBeenCalledTimes(1);
+        expect(mockDelete).toHaveBeenCalledWith(expectedUrl, expectedConfig);
+        expect(deleteResponse).toStrictEqual(mockDeleteResponse);
+      });
+    });
+  });
+
+  describe('elements http client requests with element payloads (post, put, patch)', () => {
+    let mockPost: jest.Mock,
+      mockPut: jest.Mock,
+      mockPatch: jest.Mock,
+      mockPostResponse: string,
+      mockPutResponse: string,
+      mockPatchResponse: string;
+
+    describe('elements exists on payload', () => {
+      beforeEach(async () => {
+        mockPostResponse = chance.string();
+        mockPutResponse = chance.string();
+        mockPatchResponse = chance.string();
+        mockPost = jest.fn().mockResolvedValue(mockPostResponse);
+        mockPut = jest.fn().mockResolvedValue(mockPutResponse);
+        mockPatch = jest.fn().mockResolvedValue(mockPatchResponse);
+
+        jest.mock('@/elements', () => ({
+          ...jest.requireActual('@/elements'),
+          loadElements: jest.fn().mockReturnValue({
+            client: {
+              post: mockPost,
+              put: mockPut,
+              patch: mockPatch,
+            },
+            init: jest.fn().mockResolvedValue({}),
+            hasElement: jest.fn().mockReturnValue(true),
+          }),
+        }));
+        const { BasisTheory } = await import('@/BasisTheory');
+
+        BtElementImport = BasisTheory;
+      });
+
+      test('should delegate http client request method with elements payload to elements', async () => {
+        const btElements = await new BtElementImport().init(chance.string(), {
+          elements: true,
+        });
+        const expectedUrl = chance.url();
+        const expectedPayload = {
+          [chance.string()]: chance.string(),
+        };
+        const expectedConfig = {
+          [chance.string()]: chance.string(),
+        };
+
+        const postResponse = await btElements.post(
+          expectedUrl,
+          expectedPayload,
+          expectedConfig
+        );
+
+        expect(mockPost).toHaveBeenCalledTimes(1);
+        expect(mockPost).toHaveBeenCalledWith(
+          expectedUrl,
+          expectedPayload,
+          expectedConfig
+        );
+        expect(postResponse).toStrictEqual(mockPostResponse);
+
+        const patchResponse = await btElements.patch(
+          expectedUrl,
+          expectedPayload,
+          expectedConfig
+        );
+
+        expect(mockPatch).toHaveBeenCalledTimes(1);
+        expect(mockPatch).toHaveBeenCalledWith(
+          expectedUrl,
+          expectedPayload,
+          expectedConfig
+        );
+        expect(patchResponse).toStrictEqual(mockPatchResponse);
+
+        const putResponse = await btElements.put(
+          expectedUrl,
+          expectedPayload,
+          expectedConfig
+        );
+
+        expect(mockPut).toHaveBeenCalledTimes(1);
+        expect(mockPut).toHaveBeenCalledWith(
+          expectedUrl,
+          expectedPayload,
+          expectedConfig
+        );
+        expect(putResponse).toStrictEqual(mockPutResponse);
+      });
+    });
+
+    describe('elements does not exist on payload', () => {
+      beforeEach(async () => {
+        jest.mock('@/elements', () => ({
+          ...jest.requireActual('@/elements'),
+          loadElements: jest.fn().mockReturnValue({
+            init: jest.fn().mockResolvedValue({}),
+            hasElement: jest.fn().mockReturnValue(false),
+          }),
+        }));
+        const { BasisTheory } = await import('@/BasisTheory');
+
+        BtElementImport = BasisTheory;
+      });
+
+      test('should throw NoElementsError', async () => {
+        const btElements = await new BtElementImport().init(chance.string(), {
+          elements: true,
+        });
+        const expectedUrl = chance.url();
+        const expectedPayload = {
+          [chance.string()]: chance.string(),
+        };
+        const expectedConfig = {
+          [chance.string()]: chance.string(),
+        };
+
+        expect(() =>
+          btElements.post(expectedUrl, expectedPayload, expectedConfig)
+        ).toThrow(
+          'Element not found in payload. Use a regular HTTP client if no elements are needed.'
+        );
+
+        expect(() =>
+          btElements.patch(expectedUrl, expectedPayload, expectedConfig)
+        ).toThrow(
+          'Element not found in payload. Use a regular HTTP client if no elements are needed.'
+        );
+
+        expect(() =>
+          btElements.put(expectedUrl, expectedPayload, expectedConfig)
+        ).toThrow(
+          'Element not found in payload. Use a regular HTTP client if no elements are needed.'
+        );
+      });
+    });
+
+    describe('elements has not been initialized', () => {
+      beforeEach(async () => {
+        jest.mock('@/elements', () => ({
+          ...jest.requireActual('@/elements'),
+          loadElements: jest.fn().mockReturnValue({
+            init: jest.fn().mockResolvedValue({}),
+          }),
+        }));
+        const { BasisTheory } = await import('@/BasisTheory');
+
+        BtElementImport = BasisTheory;
+      });
+
+      test('should throw NoElementsError', async () => {
+        const btElements = await new BtElementImport().init(chance.string());
+        const expectedUrl = chance.url();
+        const expectedPayload = {
+          [chance.string()]: chance.string(),
+        };
+        const expectedConfig = {
+          [chance.string()]: chance.string(),
+        };
+
+        expect(() =>
+          btElements.post(expectedUrl, expectedPayload, expectedConfig)
+        ).toThrow(
+          'Elements not initialized. Use a regular HTTP client if no elements are needed.'
+        );
+
+        expect(() =>
+          btElements.patch(expectedUrl, expectedPayload, expectedConfig)
+        ).toThrow(
+          'Elements not initialized. Use a regular HTTP client if no elements are needed.'
+        );
+
+        expect(() =>
+          btElements.put(expectedUrl, expectedPayload, expectedConfig)
+        ).toThrow(
+          'Elements not initialized. Use a regular HTTP client if no elements are needed.'
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- adds interface for client for dual writing
- doesn't look like we have any tests for actually testing the calls from BT.js over to elements. it's probably fine, but currently questioning how we could test this integration
- waiting on Elements to be deployed to prod

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
