### PR TITLE
feat: support application type query param in permissions list

### DIFF
--- a/src/permissions/BasisTheoryPermissions.ts
+++ b/src/permissions/BasisTheoryPermissions.ts
@@ -1,12 +1,17 @@
-import { createRequestConfig, dataExtractor } from '@/common';
+import { createRequestConfig, dataExtractor, getQueryParams } from '@/common';
 import { BasisTheoryService } from '@/service';
 import type { Permission } from '@/types/models';
-import type { RequestOptions } from '@/types/sdk';
+import type { ListPermissionsQuery, RequestOptions } from '@/types/sdk';
 
 export class BasisTheoryPermissions extends BasisTheoryService {
-  public list(options?: RequestOptions): Promise<Permission[]> {
+  public list(
+    query?: ListPermissionsQuery,
+    options?: RequestOptions
+  ): Promise<Permission[]> {
+    const url = `/${getQueryParams(query)}`;
+
     return this.client
-      .get('/', createRequestConfig(options))
+      .get(url, createRequestConfig(options))
       .then(dataExtractor);
   }
 }

--- a/src/types/sdk/services/permissions.ts
+++ b/src/types/sdk/services/permissions.ts
@@ -1,8 +1,16 @@
 import type { Permission } from '@/types/models';
+import { ApplicationType } from '@/types/models';
 import type { RequestOptions } from './shared';
 
-interface Permissions {
-  list(options?: RequestOptions): Promise<Permission[]>;
+interface ListPermissionsQuery {
+  applicationType?: ApplicationType;
 }
 
-export type { Permissions };
+interface Permissions {
+  list(
+    query?: ListPermissionsQuery,
+    options?: RequestOptions
+  ): Promise<Permission[]>;
+}
+
+export type { Permissions, ListPermissionsQuery };

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -64,6 +64,44 @@ describe('Permissions', () => {
       });
     });
 
+    test('should list permissions w/ query', async () => {
+      const type = chance.string();
+      const description = chance.string();
+      const applicationTypes = [
+        chance.string({ alpha: true }) as ApplicationType,
+      ];
+
+      const query = {
+        applicationType: applicationTypes[0],
+      };
+      const url = `/?application_type=${query.applicationType}`;
+
+      client.onGet(url).reply(
+        200,
+        JSON.stringify([
+          {
+            type,
+            description,
+            // eslint-disable-next-line camelcase
+            application_types: applicationTypes,
+          },
+        ])
+      );
+
+      expect(await bt.permissions.list(query)).toStrictEqual([
+        {
+          type,
+          description,
+          applicationTypes,
+        },
+      ]);
+      expect(client.history.get).toHaveLength(1);
+      expect(client.history.get[0].url).toStrictEqual(url);
+      expect(client.history.get[0].headers).toMatchObject({
+        [API_KEY_HEADER]: expect.any(String),
+      });
+    });
+
     test('should list permissions w/ options', async () => {
       const type = chance.string();
       const description = chance.string();
@@ -85,7 +123,7 @@ describe('Permissions', () => {
       );
 
       expect(
-        await bt.permissions.list({
+        await bt.permissions.list(undefined, {
           apiKey: _apiKey,
           correlationId,
           idempotencyKey,


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

⚠️  Possible breaking change: adding query parameter to `permissions.list` method will break users passing custom request options.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
