### PR TITLE
feat: support token intents in 3ds, add mit props

### DIFF
--- a/src/types/models/threeds.ts
+++ b/src/types/models/threeds.ts
@@ -1,5 +1,10 @@
 interface CreateThreeDSSessionRequest {
-  pan: string;
+  /**
+   * @deprecated Use `tokenId` instead.
+   */
+  pan?: string;
+  tokenId?: string;
+  tokenIntentId?: string;
   type: 'customer' | 'merchant';
   device?: string;
   deviceInfo?: ThreeDSDeviceInfo;
@@ -19,6 +24,8 @@ interface AuthenticateThreeDSSessionRequest {
   authenticationCategory: string;
   authenticationType: string;
   challengePreference?: string;
+  requestDecoupledChallenge?: boolean;
+  decoupledChallengeMaxTime?: number;
   purchaseInfo?: ThreeDSPurchaseInfo;
   merchantInfo?: ThreeDSMerchantInfo;
   requestorInfo?: ThreeDSRequestorInfo;

--- a/test/threeds.test.ts
+++ b/test/threeds.test.ts
@@ -48,7 +48,7 @@ describe('ThreeDS', () => {
   describe('create session', () => {
     test('should create session', async () => {
       const request: CreateThreeDSSessionRequest = {
-        pan: chance.guid(),
+        tokenId: chance.guid(),
         type: chance.pickone(['customer', 'merchant']),
         device: chance.pickone([chance.string(), undefined]),
         deviceInfo: {
@@ -176,6 +176,8 @@ describe('ThreeDS', () => {
       const request: AuthenticateThreeDSSessionRequest = {
         authenticationCategory: 'payment',
         authenticationType: 'payment-transaction',
+        requestDecoupledChallenge: chance.bool(),
+        decoupledChallengeMaxTime: chance.integer(),
         purchaseInfo: {
           amount: '80000',
           currency: '826',


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds `token_id` and `token_intent_id` to 3ds session creation, deprecates pan
- Add decoupled challenge props for 3ds authentication.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
