### PR TITLE
feat: adds metadata to blur event

### DIFF
--- a/src/types/elements/events.ts
+++ b/src/types/elements/events.ts
@@ -1,4 +1,9 @@
-import type { Brand, FieldError, ListenableKey, Targeted } from './shared';
+import type {
+  CardMetadata,
+  ElementMetadata,
+  ListenableKey,
+  Targeted,
+} from './shared';
 
 type EventType = 'ready' | 'change' | 'focus' | 'blur' | 'keydown';
 
@@ -8,23 +13,15 @@ interface BaseEvent<T extends EventType> {
 
 type ReadyEvent = BaseEvent<'ready'>;
 
-type ChangeEvent = BaseEvent<'change'> & {
-  empty: boolean;
-  complete: boolean;
-  valid?: boolean;
-  maskSatisfied?: boolean;
-  errors?: FieldError[];
-};
+type ChangeEvent = BaseEvent<'change'> & ElementMetadata;
 
-type CardChangeEvent = ChangeEvent & {
-  cardBrand: Brand;
-  cardLast4?: string;
-  cardBin?: string;
-};
+type BlurEvent = BaseEvent<'blur'> & ElementMetadata;
+
+type CardChangeEvent = ChangeEvent & CardMetadata;
 
 type InputFocusEvent = BaseEvent<'focus'> & Targeted;
 
-type InputBlurEvent = BaseEvent<'blur'> & Targeted;
+type InputBlurEvent = BlurEvent & Targeted;
 
 type InputKeydownEvent = BaseEvent<'keydown'> &
   Targeted & {

--- a/src/types/elements/shared.ts
+++ b/src/types/elements/shared.ts
@@ -33,16 +33,16 @@ interface PropertyError {
 
 interface ElementMetadata {
   complete: boolean;
-  valid: boolean;
-  maskSatisfied?: boolean;
   empty: boolean;
   errors?: FieldError[] | Omit<FieldError, 'targetId'>[];
+  maskSatisfied?: boolean;
+  valid: boolean;
 }
 
 interface CardMetadata {
+  cardBin?: string;
   cardBrand: Brand;
   cardLast4?: string;
-  cardBin?: string;
 }
 
 /**


### PR DESCRIPTION
refactor: reuse existing element metadata and card metadata interfaces

<!-- Describe your changes in detail -->
## Description

- feat: adds metadata to blur event

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
