### PR TITLE
fix: allow api base urls with subpaths

### DIFF
--- a/src/BasisTheory.ts
+++ b/src/BasisTheory.ts
@@ -156,7 +156,7 @@ export class BasisTheory
           baseUrlObject.protocol = 'https';
         }
 
-        baseUrl = baseUrlObject.toString().replace(/\/$/u, '');
+        baseUrl = `${baseUrlObject.toString().replace(/\/$/u, '')}/`;
       } catch {
         throw new Error('Invalid format for the given API base url.');
       }

--- a/src/types/elements/options.ts
+++ b/src/types/elements/options.ts
@@ -18,6 +18,7 @@ interface ElementInternalOptions {
   baseUrl: string;
   type: ElementType;
   useNgApi: boolean | undefined;
+  useSameOriginApi: boolean | undefined;
   disableTelemetry?: boolean | undefined;
 }
 

--- a/test/clients.test.ts
+++ b/test/clients.test.ts
@@ -150,7 +150,7 @@ describe('clients', () => {
 
     await bt.tokens.retrieve(id);
     expect(mockClient.history.get[0].baseURL).toBe(
-      `${url}/path/${CLIENT_BASE_PATHS.tokens}`
+      `${url}/subpath/${CLIENT_BASE_PATHS.tokens}`
     );
   });
 

--- a/test/clients.test.ts
+++ b/test/clients.test.ts
@@ -130,6 +130,30 @@ describe('clients', () => {
     );
   });
 
+  test('should be able to handle base URLs with subpath with trailing slash', async () => {
+    const chance = new Chance();
+    const url = chance.url({
+      protocol: 'https',
+      path: '',
+    });
+    const id = chance.string();
+
+    const bt = await new BasisTheory().init(chance.string(), {
+      apiBaseUrl: `${url}/subpath/`,
+    });
+
+    const mockClient = new MockAdapter(
+      ((bt.tokens as unknown) as BasisTheoryService).client
+    );
+
+    mockClient.onGet(id).reply(200, {});
+
+    await bt.tokens.retrieve(id);
+    expect(mockClient.history.get[0].baseURL).toBe(
+      `${url}/path/${CLIENT_BASE_PATHS.tokens}`
+    );
+  });
+
   test('should be able to handle base URLs without trailing slash', async () => {
     const chance = new Chance();
     const url = chance
@@ -153,6 +177,30 @@ describe('clients', () => {
     await bt.tokens.retrieve(id);
     expect(mockClient.history.get[0].baseURL).toBe(
       `${url}/${CLIENT_BASE_PATHS.tokens}`
+    );
+  });
+
+  test('should be able to handle base URLs with subpath without trailing slash', async () => {
+    const chance = new Chance();
+    const url = chance.url({
+      protocol: 'https',
+      path: '',
+    });
+    const id = chance.string();
+
+    const bt = await new BasisTheory().init(chance.string(), {
+      apiBaseUrl: `${url}/subpath`,
+    });
+
+    const mockClient = new MockAdapter(
+      ((bt.tokens as unknown) as BasisTheoryService).client
+    );
+
+    mockClient.onGet(id).reply(200, {});
+
+    await bt.tokens.retrieve(id);
+    expect(mockClient.history.get[0].baseURL).toBe(
+      `${url}/subpath/${CLIENT_BASE_PATHS.tokens}`
     );
   });
 });

--- a/test/elements.test.ts
+++ b/test/elements.test.ts
@@ -99,7 +99,7 @@ describe('Elements', () => {
       ).resolves.toBe(bt);
     });
 
-    test('should initialize BasisTheoryElements with useNgApi false if not specified', async () => {
+    test('should initialize BasisTheoryElements with useNgApi and useSameOriginApi false if not specified', async () => {
       let loadElements: () => unknown = jest.fn();
 
       jest.isolateModules(() => {
@@ -131,7 +131,7 @@ describe('Elements', () => {
       );
     });
 
-    test('should initialize BasisTheoryElements with specified useNgApi param', async () => {
+    test('should initialize BasisTheoryElements with specified useNgApi and useSameOriginApi params', async () => {
       let loadElements: () => unknown = jest.fn();
 
       jest.isolateModules(() => {


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Allow API base urls with subpaths
  - Context: we were removing trailing slash but when doing `new URL` that strips the path if its not included
  - Fix was to manually add back a trailing slash at the end of the url after we strip any existing ones (could be multiple)

- Add `useSameOriginApi` prop in a missed place

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
