### PR TITLE
feat: add debug init option

### DIFF
--- a/src/BasisTheory.ts
+++ b/src/BasisTheory.ts
@@ -76,6 +76,7 @@ const defaultInitOptions: Required<BasisTheoryInitOptionsWithoutElements> = {
   apiBaseUrl: DEFAULT_BASE_URL,
   elements: false,
   disableTelemetry: false,
+  debug: false,
   appInfo: {},
 };
 
@@ -171,11 +172,13 @@ export class BasisTheory
         apiKey,
         baseURL: new URL(CLIENT_BASE_PATHS.tokens, baseUrl).toString(),
         appInfo,
+        debug: this._initOptions.debug,
       });
       this._tokenize = new (delegateTokenize(this._elements))({
         apiKey,
         baseURL: new URL(CLIENT_BASE_PATHS.tokenize, baseUrl).toString(),
         appInfo,
+        debug: this._initOptions.debug,
       });
       this._applications = new BasisTheoryApplications({
         apiKey,
@@ -229,11 +232,13 @@ export class BasisTheory
         apiKey,
         baseURL: new URL(CLIENT_BASE_PATHS.proxy, baseUrl).toString(),
         appInfo,
+        debug: this._initOptions.debug,
       });
       this._sessions = new BasisTheorySessions({
         apiKey,
         baseURL: new URL(CLIENT_BASE_PATHS.sessions, baseUrl).toString(),
         appInfo,
+        debug: this._initOptions.debug,
       });
       this._threeds = new BasisTheoryThreeDS({
         apiKey,
@@ -244,6 +249,7 @@ export class BasisTheory
         apiKey,
         baseURL: new URL(CLIENT_BASE_PATHS.tokenIntents, baseUrl).toString(),
         appInfo,
+        debug: this._initOptions.debug,
       });
 
       if (options.disableTelemetry) {

--- a/src/common/BasisTheoryApiError.ts
+++ b/src/common/BasisTheoryApiError.ts
@@ -2,7 +2,8 @@ export class BasisTheoryApiError extends Error {
   public constructor(
     message: string,
     public readonly status: number,
-    public readonly data?: unknown
+    public readonly data?: unknown,
+    public readonly _debug?: Record<string, unknown>
   ) {
     super(message);
     this.name = 'BasisTheoryApiError';

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -4,6 +4,8 @@ const API_KEY_HEADER = 'BT-API-KEY';
 
 const BT_TRACE_ID_HEADER = 'bt-trace-id';
 
+const CF_RAY_HEADER = 'cf-ray';
+
 const BT_IDEMPOTENCY_KEY_HEADER = 'bt-idempotency-key';
 
 const BT_EXPOSE_PROXY_RESPONSE_HEADER = 'BT-EXPOSE-RAW-PROXY-RESPONSE';
@@ -99,4 +101,5 @@ export {
   BROWSER_LIST,
   DD_TOKEN,
   DD_GIT_SHA,
+  CF_RAY_HEADER,
 };

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -34,6 +34,7 @@ import {
   BROWSER_LIST,
   BT_IDEMPOTENCY_KEY_HEADER,
   BT_TRACE_ID_HEADER,
+  CF_RAY_HEADER,
   CLIENT_USER_AGENT_HEADER,
   USER_AGENT_CLIENT,
 } from './constants';
@@ -494,6 +495,20 @@ const buildClientUserAgentString = (appInfo?: ApplicationInfo): string => {
   return JSON.stringify(snakecaseKeys(clientUserAgent));
 };
 
+const debugTransform: AxiosResponseTransformer = (data, headers) => {
+  if (headers && typeof data === 'object' && data !== undefined) {
+    // we are deliberately mutating the data object here to include the debug headers
+    // eslint-disable-next-line no-param-reassign
+    data._debug = {
+      ...data._debug,
+      cfRay: headers[CF_RAY_HEADER],
+      btTraceId: headers[BT_TRACE_ID_HEADER],
+    };
+  }
+
+  return data;
+};
+
 export {
   assertInit,
   transformRequestSnakeCase,
@@ -517,4 +532,5 @@ export {
   getOSVersion,
   getRuntime,
   getBrowser,
+  debugTransform,
 };

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -315,9 +315,18 @@ const createRequestConfig = (
   };
 };
 
-const errorInterceptor = (error: AxiosError): void => {
-  const status = error.response?.status ?? -1;
-  const data = error.response?.data;
+const handleAxiosError = (error: AxiosError, debug?: boolean): void => {
+  const status = error?.response?.status ?? -1;
+  const data = error?.response?.data;
+
+  let _debug;
+
+  if (debug) {
+    _debug = {
+      cfRay: error?.response?.headers?.[CF_RAY_HEADER],
+      btTraceId: error?.response?.headers?.[BT_TRACE_ID_HEADER],
+    };
+  }
 
   const logSeverity = status > -1 && status < 499 ? 'warn' : 'error';
 
@@ -347,8 +356,14 @@ const errorInterceptor = (error: AxiosError): void => {
     }
   );
 
-  throw new BasisTheoryApiError(error.message, status, data);
+  throw new BasisTheoryApiError(error.message, status, data, _debug);
 };
+
+const errorInterceptor = (error: AxiosError): void =>
+  handleAxiosError(error, false);
+
+const errorInterceptorDebug = (error: AxiosError): void =>
+  handleAxiosError(error, true);
 
 const getQueryParams = <Q>(query: Q = {} as Q): string => {
   const keys = Object.keys(query as Record<string, unknown>) as (keyof Q)[];
@@ -533,4 +548,5 @@ export {
   getRuntime,
   getBrowser,
   debugTransform,
+  errorInterceptorDebug,
 };

--- a/src/service/BasisTheoryService.ts
+++ b/src/service/BasisTheoryService.ts
@@ -13,6 +13,7 @@ import {
   transformResponseCamelCase,
   buildUserAgentString,
   buildClientUserAgentString,
+  debugTransform,
 } from '@/common';
 import { BasisTheoryServiceOptions } from './types';
 
@@ -28,6 +29,7 @@ export abstract class BasisTheoryService<
       transformRequest,
       transformResponse,
       appInfo,
+      debug,
     } = options;
 
     if (typeof axios === 'string') {
@@ -53,7 +55,8 @@ export abstract class BasisTheoryService<
         ),
         transformResponse: (axios.defaults
           .transformResponse as AxiosResponseTransformer[]).concat(
-          transformResponse || transformResponseCamelCase
+          transformResponse || transformResponseCamelCase,
+          debug ? debugTransform : []
         ),
         /* eslint-enable unicorn/prefer-spread */
       });

--- a/src/service/BasisTheoryService.ts
+++ b/src/service/BasisTheoryService.ts
@@ -14,6 +14,7 @@ import {
   buildUserAgentString,
   buildClientUserAgentString,
   debugTransform,
+  errorInterceptorDebug,
 } from '@/common';
 import { BasisTheoryServiceOptions } from './types';
 
@@ -60,7 +61,10 @@ export abstract class BasisTheoryService<
         ),
         /* eslint-enable unicorn/prefer-spread */
       });
-      this.client.interceptors.response.use(undefined, errorInterceptor);
+      this.client.interceptors.response.use(
+        undefined,
+        debug ? errorInterceptorDebug : errorInterceptor
+      );
     }
   }
 }

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -5,6 +5,7 @@ interface BasisTheoryServiceOptions
   extends Pick<AxiosRequestConfig, 'transformRequest' | 'transformResponse'> {
   apiKey: string;
   baseURL: string;
+  debug?: boolean;
   appInfo?: ApplicationInfo;
 }
 

--- a/src/types/models/token-intents.ts
+++ b/src/types/models/token-intents.ts
@@ -32,6 +32,7 @@ type TokenIntent<DataType = DataObject> = (TokenBase<DataType> &
     tenantId: string;
     expiresAt: string;
     fingerprint?: string;
+    _debug?: Record<string, unknown>;
   }) &
   (
     | TokenTypeMap[TokenTypesForTokenIntents]

--- a/src/types/models/tokenize.ts
+++ b/src/types/models/tokenize.ts
@@ -12,6 +12,8 @@ type TokenizeArray<DataType = Primitive> = Array<
 >;
 type TokenizeData<DataType = Primitive> =
   | TokenizeArray<DataType>
-  | TokenizeObject<DataType>;
+  | (TokenizeObject<DataType> & {
+      _debug?: Record<string, unknown>;
+    });
 
 export type { TokenizeObject, TokenizeArray, TokenizeData };

--- a/src/types/models/tokens.ts
+++ b/src/types/models/tokens.ts
@@ -54,6 +54,7 @@ type Token<DataType = Primitive> = TokenBase<DataType> & {
   tenantId: string;
   fingerprint?: string;
   metadata?: Record<string, string>;
+  _debug?: Record<string, unknown>;
 };
 
 type CreateToken<DataType = Primitive> = Pick<
@@ -71,6 +72,7 @@ type CreateToken<DataType = Primitive> = Pick<
 > & {
   deduplicateToken?: boolean;
   id?: string;
+  _debug?: Record<string, unknown>;
 };
 
 type UpdateToken<DataType = Primitive> = Partial<
@@ -87,6 +89,7 @@ type UpdateToken<DataType = Primitive> = Partial<
   > & {
     privacy: Omit<TokenPrivacy, 'classification'>;
     deduplicateToken: boolean;
+    _debug?: Record<string, unknown>;
   }
 >;
 

--- a/src/types/sdk/sdk.ts
+++ b/src/types/sdk/sdk.ts
@@ -28,6 +28,7 @@ interface BasisTheoryInitOptions {
   apiBaseUrl?: string;
   appInfo?: ApplicationInfo;
   disableTelemetry?: boolean;
+  debug?: boolean;
 }
 
 interface BasisTheoryInitOptionsWithoutElements extends BasisTheoryInitOptions {

--- a/src/types/sdk/services/sessions.ts
+++ b/src/types/sdk/services/sessions.ts
@@ -12,6 +12,7 @@ type CreateSessionResponse = {
   sessionKey: string;
   nonce: string;
   expiresAt: string;
+  _debug?: Record<string, unknown>;
 };
 
 interface Sessions {


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Add `debug` init option that will add a `_debug` object containing `bt-trace-id` and `cf-ray` response headers

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
