### PR TITLE
fix(ENG-11189): replace terraform-admin role chain with scoped IAM roles

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -92,15 +92,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::914054469264:role/github-actions-admin-dev
+          role-to-assume: arn:aws:iam::914054469264:role/basis-theory-js-gh-admin
           aws-region: us-east-2
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::914054469264:role/terraform-admin
-          aws-region: us-east-2
-          role-chaining: true
 
       - name: Deploy Index Hash
         run: make deploy-index-hash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,15 +73,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::469828239459:role/github-actions-admin-prod
+          role-to-assume: arn:aws:iam::469828239459:role/basis-theory-js-gh-admin
           aws-region: us-east-2
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::469828239459:role/terraform-admin
-          aws-region: us-east-2
-          role-chaining: true
 
       - name: UAT Deploy Index Hash
         run: make deploy-index-hash
@@ -130,15 +123,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::244923700941:role/github-actions-admin-uat
+          role-to-assume: arn:aws:iam::244923700941:role/basis-theory-js-gh-admin
           aws-region: us-east-2
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::244923700941:role/terraform-admin
-          aws-region: us-east-2
-          role-chaining: true
 
       - name: UAT Deploy Index Hash
         run: make deploy-index-hash


### PR DESCRIPTION
## Description

- Replace the `github-actions-admin-dev` → `terraform-admin` role chain in `pull-request.yml` with a single scoped role `basis-theory-js-gh-admin` (dev account `914054469264`)
- Replace the `github-actions-admin-prod` → `terraform-admin` role chain in `release.yml` (`build-release` job) with `basis-theory-js-gh-admin` (prod account `469828239459`)
- Replace the `github-actions-admin-uat` → `terraform-admin` role chain in `release.yml` (`release-to-uat` job) with `basis-theory-js-gh-admin` (UAT account `244923700941`)
- All jobs already have the correct `environment:` declaration (DEV/PROD/UAT) so OIDC sub claims are correct
- Unblocks the currently failing PR workflow: `build (14.x, ubuntu-latest)` was failing with `Not authorized to perform sts:AssumeRoleWithWebIdentity` against the old `github-actions-admin-dev` role — broken by the terraform changes in `basistheory-vault-api` ENG-11178 which tightened/scoped the shared admin roles
- **Depends on tf-aws-global `ENG-11189-basis-theory-js-iam` being applied first** to create the `basis-theory-js-gh-admin` role in all three accounts
- Part of ENG-11174 — migrating all repos off `terraform-admin` role chaining to per-repo scoped IAM roles

## Testing required outside of automated testing?

- [x] Not Applicable

### Screenshots (if appropriate):

- [x] Not Applicable

## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [x] Description of Change
- [x] Description of outside testing if applicable.
- [x] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change