### PR TITLE
fix(ENG-11520): replace semantic-release PAT with bt_semantic_release app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,8 @@ jobs:
   build-release:
     environment: PROD
     permissions:
-      id-token: write
-      contents: write
-      issues: write
+      id-token: write # npm OIDC trusted publishing
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -20,31 +19,41 @@ jobs:
       CI: 1 # prevents extra Cypress installation progress messages
       HUSKY: 0 # disables husky hooks
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - name: Mint semantic-release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          token: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
+          app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Checkout repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Rclone
-        uses: AnimMouse/setup-rclone@v1
+        uses: AnimMouse/setup-rclone@26ef2133e09fd383329a1d4c1fbe6a71db1976c9 # v1
 
       - name: Start Deploy Message
-        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
           # registry-url is intentionally NOT set - it writes an .npmrc auth line that blocks OIDC
 
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest # Requires npm 11.5.1+ for OIDC trusted publishing
+        run: npm install -g npm@11.18.0 # Pinned; requires npm 11.5.1+ for OIDC trusted publishing
 
       - name: Install deps (with cache)
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
         env:
           CYPRESS_INSTALL_BINARY: 0
 
@@ -60,7 +69,7 @@ jobs:
           SKIP_INSTALL: 1 # install with cache was done already
 
       - name: Create dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
           path: dist
@@ -72,7 +81,7 @@ jobs:
           AWS_REGION: us-east-2
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_ID }}
           ENVIRONMENT: prod
-          GITHUB_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # semantic-release (above) bumps dist/package.json and creates the GitHub release/tag/changelog,
       # but does NOT publish to npm. Publishing happens here as a plain step so npm can perform the
@@ -81,7 +90,7 @@ jobs:
         run: cd dist && npm publish --provenance --access public
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::469828239459:role/basis-theory-js-gh-admin
           aws-region: us-east-2
@@ -93,21 +102,21 @@ jobs:
           ENVIRONMENT:  prod
 
       - name: Purge cache
-        uses: jakejarvis/cloudflare-purge-action@master
+        uses: jakejarvis/cloudflare-purge-action@eee6dba0236093358f25bb1581bd615dc8b3d8e3 # master
         env:
           CLOUDFLARE_ZONE: ${{ vars.CF_PROD_ZONE_ID }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_PURGE_TOKEN }}
           PURGE_URLS: '["https://js.basistheory.com/*"]'
 
       - name: Purge prod wl cache
-        uses: jakejarvis/cloudflare-purge-action@master
+        uses: jakejarvis/cloudflare-purge-action@eee6dba0236093358f25bb1581bd615dc8b3d8e3 # master
         env:
           CLOUDFLARE_ZONE: ${{ vars.CF_PROD_ELEMENTS_ZONE_ID }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_PURGE_TOKEN }}
 
       - name: Stop Deploy Message
         if: always()
-        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}
@@ -122,16 +131,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download Client dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: dist
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::244923700941:role/basis-theory-js-gh-admin
           aws-region: us-east-2
@@ -143,14 +152,14 @@ jobs:
           ENVIRONMENT:  uat
 
       - name: Purge uat cache
-        uses: jakejarvis/cloudflare-purge-action@master
+        uses: jakejarvis/cloudflare-purge-action@eee6dba0236093358f25bb1581bd615dc8b3d8e3 # master
         env:
           CLOUDFLARE_ZONE: ${{ vars.CF_UAT_ZONE_ID }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_PURGE_TOKEN }}
           PURGE_URLS: '["https://js.btsandbox.com/*"]'
 
       - name: Purge uat wl cache
-        uses: jakejarvis/cloudflare-purge-action@master
+        uses: jakejarvis/cloudflare-purge-action@eee6dba0236093358f25bb1581bd615dc8b3d8e3 # master
         env:
           CLOUDFLARE_ZONE: ${{ vars.CF_UAT_ELEMENTS_ZONE_ID }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_PURGE_TOKEN }}


### PR DESCRIPTION
## Description
Part of ENG-11520 (semantic-release special-case migration; follow-up to ENG-11425). Migrates `basis-theory-js` off the `GH_SEMANTIC_RELEASE_PAT` org PAT onto a short-lived `bt_semantic_release` GitHub App token. npm publishing already moved to OIDC trusted publishing under ENG-11174, so this PR only touches the semantic-release git/GitHub auth path.

- Mint a `bt_semantic_release` app token (least-privilege `permission-contents/issues/pull-requests: write`) and use it for both the checkout and the `make release` (`GITHUB_TOKEN`) semantic-release operations.
- Drop the job's default-token `contents: write` / `issues: write` down to `contents: read` — the app token now performs all writes; `id-token: write` is retained for npm OIDC.
- npm OIDC publishing (`npm publish --provenance`, no `NPM_TOKEN`) is unchanged and continues to use the native workflow identity — never the app token.
- Exact-pin `npm@11.18.0` (was `npm@latest`; still ≥11.5.1 for OIDC) and SHA-pin all actions in the workflow.

## Business Impact
- Minimal — release-pipeline auth hardening. No published-package or runtime change.

## Testing required outside of automated testing?
- [x] Required — validated end-to-end via a real `basis-theory-js` release (tag/changelog/GitHub release + npm provenance publish + UAT deploy) after the app key is provisioned.

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Back
- Revert this PR to restore the PAT-based checkout/`GITHUB_TOKEN`.

## Documentation
- Tracked in ENG-11520 / ENG-10249.

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change